### PR TITLE
Don't disable audio processing prematurely

### DIFF
--- a/build/patches/disable_mute_of_audio_processing.patch
+++ b/build/patches/disable_mute_of_audio_processing.patch
@@ -1,0 +1,24 @@
+diff --git a/media/engine/webrtc_voice_engine.cc b/media/engine/webrtc_voice_engine.cc
+index 35e2657876..be6ed226f1 100644
+--- a/media/engine/webrtc_voice_engine.cc
++++ b/media/engine/webrtc_voice_engine.cc
+@@ -2280,6 +2280,19 @@ bool WebRtcVoiceMediaChannel::MuteStream(uint32_t ssrc, bool muted) {
+   for (const auto& kv : send_streams_) {
+     all_muted = all_muted && kv.second->muted();
+   }
++  // Because multiple WebRTCVoiceMediaChannels can be
++  // associated with a single AudioProcessing module,
++  // muting when all streams of this media channel
++  // are muted is incorrect, because streams on other
++  // channels may not be muted.  So, for now,
++  // we'll simply not disable audio processing when
++  // streams are muted.
++  //
++  // TODO(roxanneskelly)
++  // Track which WebRTCVoiceMediaChannels are all_muted
++  // and only call set_output_will_be_muted when all of them
++  // are muted.
++  all_muted = false;
+   webrtc::AudioProcessing* ap = engine()->apm();
+   if (ap) {
+     ap->set_output_will_be_muted(all_muted);

--- a/build/run.py
+++ b/build/run.py
@@ -185,6 +185,7 @@ PATCHES = {
         'is_pod-is-deprecated.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
         'msvc-checks-template.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'windows_x86': [
         'add_license_dav1d.patch',
@@ -194,6 +195,7 @@ PATCHES = {
         'is_pod-is-deprecated.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
         'msvc-checks-template.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'windows_arm64': [
         'add_license_dav1d.patch',
@@ -203,76 +205,90 @@ PATCHES = {
         'is_pod-is-deprecated.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
         'msvc-checks-template.patch'
+        'disable_mute_of_audio_processing.patch',
     ],
     'macos_x86_64': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'macos_h264_encoder.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'macos_arm64': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'macos_h264_encoder.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'ios': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'macos_h264_encoder.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'android': [
         'add_license_dav1d.patch',
         'android_webrtc_version.patch',
         'fix_mocks.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'android_prefixed': [
         'add_license_dav1d.patch',
         'android_webrtc_version.patch',
         'fix_mocks.patch',
-        'jni_prefix.patch'
+        'jni_prefix.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'raspberry-pi-os_armv6': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'raspberry-pi-os_armv7': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'raspberry-pi-os_armv8': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'ubuntu-18.04_armv8': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'ubuntu-20.04_armv8': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'ubuntu-18.04_x86_64': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'ubuntu-20.04_x86_64': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
     'ubuntu-22.04_x86_64': [
         'add_license_dav1d.patch',
         'fix_mocks.patch',
         'upsample-to-48khz-for-echo-cancellation-for-now.patch',
+        'disable_mute_of_audio_processing.patch',
     ],
 }
 


### PR DESCRIPTION
Multiple WebRTCVoiceMediaChannels can be associated with a single AudioProcessing module.  Disabling some of the audio processing when a single WebRTCVoiceMediaChannel's streams mute is incorrect, as it may disable audio processing for the other
WebRTCVoiceMediaChannels.

For now, don't disable any of the audio processing.  This may use more, but it won't be much.