### PR TITLE
Condensed changes to enable linux64 builds on roxie/m137-universal-mac branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,8 +84,8 @@ jobs:
           # - ubuntu-18.04_armv8
           # - ubuntu-20.04_armv8
           # - ubuntu-18.04_x86_64
-          - ubuntu-20.04_x86_64
-          # - ubuntu-22.04_x86_64
+          # - ubuntu-20.04_x86_64
+          - ubuntu-22.04_x86_64
           # - android
           # - android_prefixed
     runs-on: linux-large

--- a/build-local.sh
+++ b/build-local.sh
@@ -37,7 +37,7 @@ case "$AUTOBUILD_PLATFORM" in
         autobuild="$AUTOBUILD"
     ;;
     linux*)
-        build_type="ubuntu-20.04_x86_64"
+        build_type="ubuntu-22.04_x86_64"
         autobuild="$AUTOBUILD"
     ;;
     *)

--- a/build/patches/enable_gcc_permissive.patch
+++ b/build/patches/enable_gcc_permissive.patch
@@ -1,0 +1,15 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index e4a82bc8d6..54fde4ce9a 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -384,6 +384,10 @@ config("common_config") {
+       # warning.
+       "-Wctad-maybe-unsupported",
+     ]
++  } else {
++    if(is_linux) {
++      cflags += [ "-fpermissive" ]
++    }
+   }
+ 
+   if (build_with_chromium) {

--- a/build/patches/gcc_fpermissive_error.patch
+++ b/build/patches/gcc_fpermissive_error.patch
@@ -1,0 +1,12 @@
+diff -durN webrtc-m137/p2p/base/port_interface.h webrtc-m137-patched/p2p/base/port_interface.h
+--- webrtc-m137/p2p/base/port_interface.h	2025-09-01 14:30:40.000000000 +0200
++++ webrtc-m137-patched/p2p/base/port_interface.h	2025-09-05 15:07:36.904283022 +0200
+@@ -55,7 +55,7 @@
+   virtual ~PortInterface();
+ 
+   virtual IceCandidateType Type() const = 0;
+-  virtual const Network* Network() const = 0;
++  virtual const webrtc::Network* Network() const = 0;
+ 
+   // Methods to set/get ICE role and tiebreaker values.
+   virtual void SetIceRole(IceRole role) = 0;

--- a/build/run.py
+++ b/build/run.py
@@ -768,7 +768,8 @@ def build_webrtc(
                 f'target_cpu="{target_cpus[target]}"',
                 "use_custom_libcxx=false",
                 "use_custom_libcxx_for_host=false",
-                "is_clang=true"
+                "is_clang=true",
+                'use_lld=false',
             ]
         elif target in ('macos_x86_64', 'macos_arm64'):
             gn_args += [

--- a/build/run.py
+++ b/build/run.py
@@ -268,6 +268,8 @@ PATCHES = {
         'bug_8759_workaround.patch',
         'disable_mute_of_audio_processing.patch',
         'crash_on_fatal_error.patch',
+        'gcc_fpermissive_error.patch',
+        'enable_gcc_permissive.patch',
     ],
     'raspberry-pi-os_armv7': [
         'add_license_dav1d.patch',
@@ -276,6 +278,8 @@ PATCHES = {
         'bug_8759_workaround.patch',
         'disable_mute_of_audio_processing.patch',
         'crash_on_fatal_error.patch',
+        'gcc_fpermissive_error.patch',
+        'enable_gcc_permissive.patch',
     ],
     'raspberry-pi-os_armv8': [
         'add_license_dav1d.patch',
@@ -284,6 +288,8 @@ PATCHES = {
         'bug_8759_workaround.patch',
         'disable_mute_of_audio_processing.patch',
         'crash_on_fatal_error.patch',
+        'gcc_fpermissive_error.patch',
+        'enable_gcc_permissive.patch',
     ],
     'ubuntu-18.04_armv8': [
         'add_license_dav1d.patch',
@@ -292,6 +298,8 @@ PATCHES = {
         'bug_8759_workaround.patch',
         'disable_mute_of_audio_processing.patch',
         'crash_on_fatal_error.patch',
+        'gcc_fpermissive_error.patch',
+        'enable_gcc_permissive.patch',
     ],
     'ubuntu-20.04_armv8': [
         'add_license_dav1d.patch',
@@ -300,6 +308,8 @@ PATCHES = {
         'bug_8759_workaround.patch',
         'disable_mute_of_audio_processing.patch',
         'crash_on_fatal_error.patch',
+        'gcc_fpermissive_error.patch',
+        'enable_gcc_permissive.patch',
     ],
     'ubuntu-18.04_x86_64': [
         'add_license_dav1d.patch',
@@ -308,6 +318,8 @@ PATCHES = {
         'bug_8759_workaround.patch',
         'disable_mute_of_audio_processing.patch',
         'crash_on_fatal_error.patch',
+        'gcc_fpermissive_error.patch',
+        'enable_gcc_permissive.patch',
     ],
     'ubuntu-20.04_x86_64': [
         'add_license_dav1d.patch',
@@ -316,6 +328,8 @@ PATCHES = {
         'bug_8759_workaround.patch',
         'disable_mute_of_audio_processing.patch',
         'crash_on_fatal_error.patch',
+        'gcc_fpermissive_error.patch',
+        'enable_gcc_permissive.patch',
     ],
     'ubuntu-22.04_x86_64': [
         'add_license_dav1d.patch',
@@ -324,6 +338,8 @@ PATCHES = {
         'bug_8759_workaround.patch',
         'disable_mute_of_audio_processing.patch',
         'crash_on_fatal_error.patch',
+        'gcc_fpermissive_error.patch',
+        'enable_gcc_permissive.patch',
     ],
 }
 
@@ -374,7 +390,7 @@ def get_webrtc(source_dir, patch_dir, version, target,
                 cmd(['git', 'branch'])
                 cmd(['git', 'checkout', '-f', version])
             cmd(['git', 'clean', '-df'])
-            cmd(['gclient', 'sync', '-D', '--force', '--reset', '--with_branch_heads', '--jobs=8'])
+            cmd(['gclient', 'sync', '-D', '--force', '--reset', '--revision', version, '--no-history', '--jobs=8'])
             for patch in PATCHES[target]:
                 depth, dirs = PATCH_INFO.get(patch, (1, ['.']))
                 dir = os.path.join(src_dir, *dirs)
@@ -797,9 +813,14 @@ def build_webrtc(
             gn_args += [
                 'target_os="linux"',
                 'rtc_use_pipewire=false',
+                'rtc_use_x11=false',
                 "use_custom_libcxx=false",
                 "use_custom_libcxx_for_host=false",
-                'rtc_include_pulse_audio=false',
+                'is_clang=false',
+                'clang_use_chrome_plugins=false',
+                'use_lld=false',
+                'use_thin_lto=false',
+                'rtc_include_pulse_audio=true',
                 'rtc_include_internal_audio_device=true',
             ]
         else:
@@ -824,10 +845,8 @@ def build_webrtc(
 
     if target in ['windows_x86_64', 'windows_x86', 'windows_arm64']:
         pass
-    elif target in ('macos_x86_64', 'macos_arm64'):
-        ar = '/usr/bin/ar'
     else:
-        ar = os.path.join(webrtc_src_dir, 'third_party/llvm-build/Release+Asserts/bin/llvm-ar')
+        ar = '/usr/bin/ar'
 
     # ar で libwebrtc.a を生成する
     # Create libwebrtc.a with ar
@@ -1218,7 +1237,7 @@ def main():
             commit = version_info.webrtc_commit
             if args.commit:
                 commit = args.commit
-            
+
             print("Building for commit: ", commit)
 
             # ソース取得

--- a/build/scripts/apt_install_x86_64.sh
+++ b/build/scripts/apt_install_x86_64.sh
@@ -8,7 +8,7 @@ apt-get -y upgrade
 # tzdata を noninteractive にしないと実行が止まってしまう
 # need to set tzdata to noninteractive or else it'll stop
 apt-get -y install tzdata
-echo 'Asia/Tokyo' > /etc/timezone
+echo 'America/New_York' > /etc/timezone
 dpkg-reconfigure -f noninteractive tzdata
 
 export DEBIAN_FRONTEND=noninteractive
@@ -27,4 +27,5 @@ apt-get -y install \
   unzip \
   vim \
   wget \
-  xz-utils
+  xz-utils \
+  build-essential


### PR DESCRIPTION
This enables functional linux builds on the roxie/m137-universal-mac branch

* Switches to system compiler and ar on Linux to fix incompatibilities introduced by special chromium toolchain
* Enables pulseaudio so device selection shows user friendly names
* Fixes windows linking errors under recent visual studio updates
* Reduces size of cloned resources during build process to reduce build times

Includes some changes from https://github.com/secondlife/3p-webrtc-build/pull/12